### PR TITLE
add NuGet config file

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="discord-net" value="https://www.myget.org/F/discord-net/api/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Without this configuration, `dotnet restore` fails:

```bash
$ dotnet restore src/VainBot/
  Restoring packages for /app/src/VainBot/VainBot.csproj...
  Installing Nito.Disposables 1.0.0.
  Installing Nito.AsyncEx.Tasks 1.1.0.
  Installing Npgsql.EntityFrameworkCore.PostgreSQL 2.0.1.
  Installing System.ComponentModel 4.0.1.
  Installing Nito.AsyncEx.Context 1.1.0.
  Installing Autofac 4.6.2.
  Installing System.Net.Http 4.3.2.
  Installing Newtonsoft.Json 10.0.3.
  Installing TweetinviAPI 2.1.0.
  Installing Npgsql 3.2.6.
/app/src/VainBot/VainBot.csproj : error NU1102: Unable to find package Discord.Net.Commands with version (>= 2.0.0-beta2-00895)
/app/src/VainBot/VainBot.csproj : error NU1102:   - Found 21 version(s) in nuget.org [ Nearest version: 2.0.0-beta ]
/app/src/VainBot/VainBot.csproj : error NU1102: Unable to find package Discord.Net.WebSocket with version (>= 2.0.0-beta2-00895)
/app/src/VainBot/VainBot.csproj : error NU1102:   - Found 6 version(s) in nuget.org [ Nearest version: 2.0.0-beta ]
/app/src/VainBot/VainBot.csproj : error NU1102: Unable to find package Discord.Net.Core with version (>= 2.0.0-beta2-00895)
/app/src/VainBot/VainBot.csproj : error NU1102:   - Found 6 version(s) in nuget.org [ Nearest version: 2.0.0-beta ]
  Generating MSBuild file /app/src/VainBot/obj/VainBot.csproj.nuget.g.props.
  Generating MSBuild file /app/src/VainBot/obj/VainBot.csproj.nuget.g.targets.
  Restore failed in 5.68 sec for /app/src/VainBot/VainBot.csproj.
```

This file configures NuGet to use the the myget feed for unstable Discord.Net releases.